### PR TITLE
[Test]: remove webpack-stats-local.json to check travis build status

### DIFF
--- a/webpack-stats-local.json
+++ b/webpack-stats-local.json
@@ -1,1 +1,0 @@
-{"status":"done","publicPath":"http://localhost:3000/static/bundles/","chunks":{"main":[{"name":"bundle.js","publicPath":"http://localhost:3000/static/bundles/bundle.js","path":"/home/vipin/Origami/django_server/static/bundles/local/bundle.js"}]}}


### PR DESCRIPTION
[WIP]
In reference to #157 