### PR TITLE
fix(demo-description): limit length of demo description on demo card

### DIFF
--- a/Origami/src/components/home/HomePage.js
+++ b/Origami/src/components/home/HomePage.js
@@ -26,9 +26,12 @@ import {
   Modal
 } from "antd";
 import toastr from "toastr";
+import { SocialDialog } from "../social/SocialDialog";
+import { trimAndPad } from "../../utils/generalUtils";
+import { DEMO_CARD_DESCRIP_MAX_LEN } from "../../constants";
+
 const { Header, Content, Footer } = Layout;
 const Option = Select.Option;
-import { SocialDialog } from "../social/SocialDialog";
 const demoSpinnerStyle = {
   position: "fixed",
   top: "50%",
@@ -284,7 +287,12 @@ class HomePage extends React.Component {
                                 <img width="100%" src={demo.cover_image} />
                               </div>
                               <div className="custom-card">
-                                <p>{demo.description}</p>
+                                <p>
+                                  {trimAndPad(
+                                    demo.description,
+                                    DEMO_CARD_DESCRIP_MAX_LEN
+                                  )}
+                                </p>
                                 <br />
                                 <Row>
                                   <Col span={11} offset={1}>
@@ -340,7 +348,7 @@ class HomePage extends React.Component {
         </Footer>
         <SocialDialog
           shareModalOpen={this.state.shareModalOpen}
-          handleShareModal={this.handleShareModal}
+          handleShareModal={this.handleShareModal.bind(this)}
           demoBeingShown={this.state.demoBeingShown}
         />
       </Layout>

--- a/Origami/src/components/user/nonghUserProfile.js
+++ b/Origami/src/components/user/nonghUserProfile.js
@@ -14,6 +14,8 @@ import RaisedButton from "material-ui/RaisedButton";
 import toastr from "toastr";
 import { Layout, Icon, Button, Card, Row, Col, Input } from "antd";
 import Radium from "radium";
+import { trimAndPad } from "../../utils/generalUtils";
+import { DEMO_CARD_DESCRIP_MAX_LEN } from "../../constants";
 
 const { Header, Content, Footer, Sider } = Layout;
 const Search = Input.Search;
@@ -252,7 +254,12 @@ class NonGHUserProfileComponent extends React.Component {
                               <img width="100%" src={project.cover_image} />
                             </div>
                             <div className="custom-card">
-                              <p>{project.description}</p>
+                              <p>
+                                {trimAndPad(
+                                  project.description,
+                                  DEMO_CARD_DESCRIP_MAX_LEN
+                                )}
+                              </p>
                               <br />
                               IP: {project.token.split(":")[1]} <br />
                               Port: {project.token.split(":")[4]} <br />

--- a/Origami/src/components/user/userShareProfile.js
+++ b/Origami/src/components/user/userShareProfile.js
@@ -18,9 +18,12 @@ import {
   Col,
   Input
 } from "antd";
+import { SocialDialog } from "../social/SocialDialog";
+import { trimAndPad } from "../../utils/generalUtils";
+import { DEMO_CARD_DESCRIP_MAX_LEN } from "../../constants";
+
 const { Header, Content, Footer, Sider } = Layout;
 const Search = Input.Search;
-import { SocialDialog } from "../social/SocialDialog";
 
 class ShareProfileComponent extends React.Component {
   constructor(props) {
@@ -166,7 +169,12 @@ class ShareProfileComponent extends React.Component {
                                 <img width="100%" src={demo.cover_image} />
                               </div>
                               <div className="custom-card">
-                                <p>{demo.description}</p>
+                                <p>
+                                  {trimAndPad(
+                                    demo.description,
+                                    DEMO_CARD_DESCRIP_MAX_LEN
+                                  )}
+                                </p>
                                 <br />
                                 <Row>
                                   <Col span={11} offset={1}>

--- a/Origami/src/constants/index.js
+++ b/Origami/src/constants/index.js
@@ -1,2 +1,3 @@
 export const ORIGAMI_READ_THE_DOCS =
   "http://cloudcv-origami.readthedocs.io/en/latest/index.html";
+export const DEMO_CARD_DESCRIP_MAX_LEN = 75;

--- a/Origami/src/utils/generalUtils.js
+++ b/Origami/src/utils/generalUtils.js
@@ -1,0 +1,10 @@
+/**
+ * Takes a string and a number and trims the string if length is greater
+ * than the number padding it with `...`
+ *
+ * @return {String} str String to trim and pad
+ * @param  {Integer} n Maximum length the string can have
+ */
+export function trimAndPad(str, n) {
+  return str.length > n ? `${str.slice(0, n)}...` : str;
+}


### PR DESCRIPTION
- add util to trim and pad a string
- add limit on length of demo description on demo card.
- Fixes #194 

**ScreenShots**

![image](https://user-images.githubusercontent.com/21292343/37775089-03199cfe-2e08-11e8-8ad1-84a2404bec41.png)
